### PR TITLE
Bug fix.

### DIFF
--- a/src/JsonWebToken/Internal/MemberStore.cs
+++ b/src/JsonWebToken/Internal/MemberStore.cs
@@ -263,8 +263,16 @@ namespace JsonWebToken
             public int Count => 1;
 
             public IMap Add(JwtMember value)
-                => new TwoElementMap(_value1, value);
-
+            {
+                if (value.Name.Equals(_value1.Name))
+                {
+                    return new OneElementMap(value);
+                }
+                else
+                {
+                    return new TwoElementMap(_value1, value);
+                }
+            }
             public bool TryGetValue(JsonEncodedText key, out JwtMember value)
             {
                 if (key.Equals(_value1.Name))

--- a/src/JsonWebToken/Internal/NET5Adapter.cs
+++ b/src/JsonWebToken/Internal/NET5Adapter.cs
@@ -1,0 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace System.Runtime.CompilerServices
+{
+    // Required to support init only properties.
+    class IsExternalInit { }
+}

--- a/src/JsonWebToken/JsonWebToken.csproj
+++ b/src/JsonWebToken/JsonWebToken.csproj
@@ -5,6 +5,7 @@
     <TargetFrameworks Condition="'$(OS)' != 'Windows_NT'">net5.0;netstandard2.0;netcoreapp2.1;netcoreapp3.1</TargetFrameworks>
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
+    <LangVersion>9</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <SignAssembly>true</SignAssembly>

--- a/src/JsonWebToken/Writer/JwsDescriptor.cs
+++ b/src/JsonWebToken/Writer/JwsDescriptor.cs
@@ -69,7 +69,7 @@ namespace JsonWebToken
         }
 
         /// <inheritdoc/>
-        public override JwtPayload? Payload
+        public override JwtPayload Payload
         {
             get => _payload;
             set
@@ -78,8 +78,6 @@ namespace JsonWebToken
                 {
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
                 }
-
-                _payload.CopyTo(value);
                 _payload = value;
             }
         }

--- a/src/JsonWebToken/Writer/JwtDescriptor.cs
+++ b/src/JsonWebToken/Writer/JwtDescriptor.cs
@@ -18,17 +18,16 @@ namespace JsonWebToken
             _header = new JwtHeader();
         }
 
-        /// <summary>Gets the parameters header.</summary>
+        /// <summary>Gets or initializes the parameters header.</summary>
         public JwtHeader Header
         {
             get => _header;
-            set
+            init
             {
                 if (value is null)
                 {
                     ThrowHelper.ThrowArgumentNullException(ExceptionArgument.value);
                 }
-
                 _header.CopyTo(value);
                 _header = value;
             }

--- a/test/JsonWebToken.Tests/JsonObjectTests.cs
+++ b/test/JsonWebToken.Tests/JsonObjectTests.cs
@@ -27,7 +27,7 @@ namespace JsonWebToken.Tests
 
             o.Add("A", false);
             Assert.True(o.TryGetValue("A", out var vF) && vF.Value.Equals(false));
-            Assert.True(o.Count == initialMemberCount + 1);
+            Assert.Equal(initialMemberCount + 1, o.Count);
         }
     }
 }

--- a/test/JsonWebToken.Tests/JsonObjectTests.cs
+++ b/test/JsonWebToken.Tests/JsonObjectTests.cs
@@ -1,0 +1,32 @@
+﻿using JsonWebToken.Cryptography;
+using Xunit;
+
+namespace JsonWebToken.Tests
+{
+    public class JsonObjectTests
+    {
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(2)]
+        [InlineData(3)]
+        [InlineData(4)]
+        [InlineData(5)]
+        [InlineData(6)]
+        [Theory]
+        public void AddReplacesExistingMember(int initialMemberCount)
+        {
+            JsonObject o = new JsonObject();
+            for( int i = 0; i<initialMemberCount;++i)
+            {
+                o.Add(i.ToString(), "Padding");
+            }
+            o.Add("A", true);
+            Assert.True(o.TryGetValue("A", out var vT) && vT.Value.Equals(true));
+            Assert.True(o.Count == initialMemberCount + 1);
+
+            o.Add("A", false);
+            Assert.True(o.TryGetValue("A", out var vF) && vF.Value.Equals(false));
+            Assert.True(o.Count == initialMemberCount + 1);
+        }
+    }
+}

--- a/test/JsonWebToken.Tests/JsonObjectTests.cs
+++ b/test/JsonWebToken.Tests/JsonObjectTests.cs
@@ -21,7 +21,8 @@ namespace JsonWebToken.Tests
                 o.Add(i.ToString(), "Padding");
             }
             o.Add("A", true);
-            Assert.True(o.TryGetValue("A", out var vT) && vT.Value.Equals(true));
+            Assert.True(o.TryGetValue("A", out var vT));
+            Assert.True((bool)vT.Value);
             Assert.Equal(initialMemberCount + 1, o.Count);
 
             o.Add("A", false);

--- a/test/JsonWebToken.Tests/JsonObjectTests.cs
+++ b/test/JsonWebToken.Tests/JsonObjectTests.cs
@@ -22,7 +22,7 @@ namespace JsonWebToken.Tests
             }
             o.Add("A", true);
             Assert.True(o.TryGetValue("A", out var vT) && vT.Value.Equals(true));
-            Assert.True(o.Count == initialMemberCount + 1);
+            Assert.Equal(initialMemberCount + 1, o.Count);
 
             o.Add("A", false);
             Assert.True(o.TryGetValue("A", out var vF) && vF.Value.Equals(false));

--- a/test/JsonWebToken.Tests/JwsDescriptorTests.cs
+++ b/test/JsonWebToken.Tests/JwsDescriptorTests.cs
@@ -22,5 +22,44 @@ namespace JsonWebToken.Tests
                 jwt.Dispose();
             }
         }
+
+        [Fact]
+        public void DescriptorPayload_is_a_standard_ReferenceObject()
+        {
+            var descriptor = new JwsDescriptor(Jwk.None, SignatureAlgorithm.None);
+
+            var p1 = new JwtPayload { { "One", "Member" } };
+            var p1Content = p1.ToString();
+            descriptor.Payload = p1;
+
+            var p2 = new JwtPayload { { "Something", "else" } };
+            var p2Content = p2.ToString();
+            descriptor.Payload = p2;
+
+            Assert.Equal(p1Content, p1.ToString());
+            Assert.Equal(p2Content, p2.ToString());
+        }
+
+        [Fact]
+        public void DescriptorHandler_is_prefilled_from_ctor_but_can_be_initialized()
+        {
+            // Descriptor's header is preconfigured based on the ctor parameters.
+            var descriptor = new JwsDescriptor(Jwk.None, SignatureAlgorithm.HS256);
+            Assert.Equal(1, descriptor.Header.Count);
+            Assert.True(descriptor.Header.TryGetValue("alg", out var a) && a.Value.ToString() == "HS256");
+
+            // This doesn't compile and this is fine: Header is in "append" mode!
+            // descriptor.Header = new JwtHeader();
+
+            // However, thanks to the C# 9 init feature, this works.
+            var withInit = new JwsDescriptor(Jwk.None, SignatureAlgorithm.HS256)
+            {
+                Header = new JwtHeader { { "One", "Member" } }
+            };
+            Assert.Equal(2, withInit.Header.Count);
+            Assert.True(withInit.Header.TryGetValue("alg", out var a2) && a2.Value.ToString() == "HS256");
+            Assert.True(withInit.Header.TryGetValue("One", out var m) && m.Value.ToString() == "Member");
+        }
+
     }
 }


### PR DESCRIPTION
Hello,

I found a bug in the JSonObject.Add when a single member is updated.
This PR is based on 2 commits:
- The first one introduce a unit test that demonstrate the bug.
- The second one fixes it.

Hope it helps and I want to say that I like very much your implementation that I'm starting to use in one of our project. Would you accept contributions and remarks? 

For instance, in this exact JSonObject.Add case: it's actually an Update/Set - it could even be aliased by a the this[] indexer.

Thanks for this great job (and I really hope to be able to contribute to this project)!
